### PR TITLE
saveDefaultsonUpdate: insert missing upsert parameter setDefaultsOnIn…

### DIFF
--- a/lib/models/AggregationRepository.js
+++ b/lib/models/AggregationRepository.js
@@ -36,7 +36,8 @@ AggregationRepositorySchema.statics.add = function (correlationId, contextId, ev
       upsertObj,
       {
         upsert: true,
-        new: true
+        new: true,
+        setDefaultsOnInsert: true
       }
     ).exec(function (err, data) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aggregator-eip",
   "description": "Aggregattor Enterprise Integration Module",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "dependencies": {
     "amqplib": "^0.4.0",
     "async": "^1.2.0",

--- a/test/aggregationRepositoryTest.js
+++ b/test/aggregationRepositoryTest.js
@@ -81,7 +81,7 @@ describe('Test AggregationRepository Model', function () {
     data[1].events.length.should.equal(1);
   });
   
-    it('should set the createdAt field when saving a new event', function * (done) {
+  it('should set the createdAt field when saving a new event', function * (done) {
     yield AggregationRepository.add("1928372", "Route3", {name: 'Darth Veider 2'});
     var today = new Date();
     AggregationRepository.collection.findOne({correlationId: '1928372'}, function (err, doc) {

--- a/test/aggregationRepositoryTest.js
+++ b/test/aggregationRepositoryTest.js
@@ -81,16 +81,19 @@ describe('Test AggregationRepository Model', function () {
     data[1].events.length.should.equal(1);
   });
   
-    it('should set the createdAt field when saving a new event', function * () {
-    var data = yield AggregationRepository.add("1928372", "Route3", {name: 'Darth Veider 2'});
+    it('should set the createdAt field when saving a new event', function * (done) {
+    yield AggregationRepository.add("1928372", "Route3", {name: 'Darth Veider 2'});
     var today = new Date();
-    data.correlationId.should.equal('1928372');
-    data.createdAt.should.be.ok;
-    (data.createdAt instanceof Date).should.equal(true);
-    data.createdAt.getHours().should.equal(today.getHours());
-    data.createdAt.getDay().should.equal(today.getDay());
-    data.createdAt.getMonth().should.equal(today.getMonth());
-    data.createdAt.getYear().should.equal(today.getYear());
+    AggregationRepository.collection.findOne({correlationId: '1928372'}, function (err, doc) {
+      doc.correlationId.should.equal('1928372');
+      doc.createdAt.should.be.ok;
+      (doc.createdAt instanceof Date).should.equal(true);
+      doc.createdAt.getHours().should.equal(today.getHours());
+      doc.createdAt.getDay().should.equal(today.getDay());
+      doc.createdAt.getMonth().should.equal(today.getMonth());
+      doc.createdAt.getYear().should.equal(today.getYear());
+      done();
+    })
   });
   
 });


### PR DESCRIPTION
…sert

- add the upsert parameter setDefaultsOnInsert, in order to apply the defaults specified in Aggregator_repository Mongoose schema, on findAndUpdate operation.
- the AggregationRepository.collection gets the native-mongo-db driver that Mongoose wraps
- i have checked that if we comment out the setDefaultsOnInsert: true , the test "should set the createdAt field when saving a new event" does not pass